### PR TITLE
#1: Make use of improved iTunes mapping in music-metadata

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,13 +14,13 @@ async function metadata(filePath) {
     .getBase64Async(common.picture[0].format));
   return {
     title: common.title,
-    artist: common.artists && getUniqueValue(common.artists[0]),
+    artist: splitCommaSeparatedValues(common.artists),
     album: common.album,
     year: common.year && common.year.toString(),
     track: common.track.no,
-    genre: common.genre && getUniqueValue(common.genre[0]),
+    genre: splitCommaSeparatedValues(common.genre),
     picture: picture,
-    synopsis: common.description && common.description[0],
+    synopsis: common.description && common.description,
     show: common.tvShow,
     season: common.tvSeason,
     episode: common.tvEpisode,
@@ -29,8 +29,11 @@ async function metadata(filePath) {
   };
 }
 
-function getUniqueValue(value) {
-  return value && [...new Set(value.match(/(?=\S)[^,]+?(?=\s*(,|$))/g))];
+function splitCommaSeparatedValues(array) {
+  if(array && array.length === 1) {
+    return array[0].split(',').map(v => v.trim());
+  }
+  return array;
 }
 
 module.exports = metadata;

--- a/index.js
+++ b/index.js
@@ -3,40 +3,30 @@
 const mm = require('music-metadata');
 const jimp = require('jimp');
 
-function metadata(filePath) {
-  return new Promise(async (resolve, reject) => {
-    try {
-      const { native, common } = await mm.parseFile(filePath, { native: true });
-      let picture = common.picture && (await jimp.read(common.picture[0].data));
-      picture =
-        picture &&
-        (await picture
-          .resize(300, jimp.AUTO)
-          .quality(60)
-          .getBase64Async(common.picture[0].format));
-      const metadata = {
-        title: common.title,
-        artist: common.artists && getUniqueValue(common.artists[0]),
-        album: common.album,
-        year: common.year && common.year.toString(),
-        track: common.track.no,
-        genre: common.genre && getUniqueValue(common.genre[0]),
-        picture: picture
-      };
-      if (native['iTunes MP4']) {
-        const iTunes = mm.orderTags(native['iTunes MP4']);
-        metadata.synopsis = iTunes.ldes && iTunes.ldes[0];
-        metadata.show = iTunes.tvsh && iTunes.tvsh[0];
-        metadata.season = iTunes.tvsn && iTunes.tvsn[0];
-        metadata.episode = iTunes.tves && iTunes.tves[0];
-        metadata.episodeId = iTunes.tven && iTunes.tven[0];
-        metadata.network = iTunes.tvnn && iTunes.tvnn[0];
-      }
-      resolve(metadata);
-    } catch (error) {
-      reject(error);
-    }
-  });
+async function metadata(filePath) {
+  const { common } = await mm.parseFile(filePath, { native: true });
+  let picture = common.picture && (await jimp.read(common.picture[0].data));
+  picture =
+    picture &&
+    (await picture
+    .resize(300, jimp.AUTO)
+    .quality(60)
+    .getBase64Async(common.picture[0].format));
+  return {
+    title: common.title,
+    artist: common.artists && getUniqueValue(common.artists[0]),
+    album: common.album,
+    year: common.year && common.year.toString(),
+    track: common.track.no,
+    genre: common.genre && getUniqueValue(common.genre[0]),
+    picture: picture,
+    synopsis: common.description && common.description[0],
+    show: common.tvShow,
+    season: common.tvSeason,
+    episode: common.tvEpisode,
+    episodeId: common.tvEpisodeId,
+    network: common.tvNetwork
+  };
 }
 
 function getUniqueValue(value) {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,6 @@
   "homepage": "https://github.com/kyawswarthwin/easy-metadata#readme",
   "dependencies": {
     "jimp": "^0.4.0",
-    "music-metadata": "^2.6.2"
+    "music-metadata": "^2.7.1"
   }
 }


### PR DESCRIPTION
1. Required change if iTunes mapping in [music-metadata](https://github.com/Borewit/music-metadata) PR: Borewit/music-metadata#139 is merged.
2. Simplified async / await promise stuff

You may need to check [`function getUniqueValue(value)`](https://github.com/kyawswarthwin/easy-metadata/blob/2917567198b6f8090935fe865ea9851ef5efee3e/index.js#L42-L44), it takes a the first item from an array as an input, but it does return an array. Does not make sense to me.

Relates issue: #1